### PR TITLE
Don't explicitly set GH_TAGNAME.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ LIB_DEPENDS= libevent.so:devel/libevent
 USES=		cmake ssl
 USE_GITHUB=	yes
 GH_ACCOUNT=	openiked
-GH_TAGNAME=	1b25611c0ac56b5e32f361df70952d6f9037b1b3
 USE_RC_SUBR= iked
 USERS=		_iked
 GROUPS=		_iked

--- a/distinfo
+++ b/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1619632362
-SHA256 (openiked-openiked-portable-v6.9.0-1b25611c0ac56b5e32f361df70952d6f9037b1b3_GH0.tar.gz) = 91b1787609dd21c0e4c0f5ea875f718f6c54438d0932c1f611c6e302235a2c8c
-SIZE (openiked-openiked-portable-v6.9.0-1b25611c0ac56b5e32f361df70952d6f9037b1b3_GH0.tar.gz) = 296848
+TIMESTAMP = 1619785073
+SHA256 (openiked-openiked-portable-v6.9.0_GH0.tar.gz) = 091fb7bb3a1f708b8d620cb11dd5509091c0326293fb38f020a7b6c8909d19af
+SIZE (openiked-openiked-portable-v6.9.0_GH0.tar.gz) = 296532


### PR DESCRIPTION
It looks like we don't need to set the GH_TAGNAME for the release version. The tag should default to DISTVERSION which in our case is v6.9.0. As this is also the name of the git release tag it should just work.